### PR TITLE
Issues/#109 ft merkle sha3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
 # 32-bit + dash
 #    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
 # Win64
-    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+###    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
     - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 # x86_64 Linux, No wallet
@@ -44,8 +44,9 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
+    - sudo add-apt-repository ppa:deadsnakes/ppa
     - sudo apt-get update
-    - sudo apt-get install -y python3
+    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-    - sudo add-apt-repository ppa:deadsnakes/ppa
+    - sudo add-apt-repository -y ppa:deadsnakes/ppa
     - sudo apt-get update
     - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
+    - sudo apt-get update
+    - sudo apt-get install -y python3
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: trusty
 os: linux
-#language: minimal
 language: python
 python: 
   - 3.6
@@ -47,12 +46,7 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-#    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-#    - sudo apt-get update -y
-#    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-#    - export PYTHONPATH=/usr/lib/python3.6/
- #   - export PYTHONHOME=/usr/lib/python3.6/
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
 #    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then python --version; python3 --version; python3.6 --version; eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
 #    - sudo apt-get update -y
 #    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+    - export PYTHONPATH=/usr/lib/python3.6
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
 
 before_install:
     - sudo add-apt-repository -y ppa:deadsnakes/ppa
-    - sudo apt-get update
+    - sudo apt-get update -y
     - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
@@ -88,7 +88,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: trusty
 os: linux
 #language: minimal
 language: generic
-python: 3.6
+python: 
+  - 3.6
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-      #- if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+#    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 dist: trusty
 os: linux
-language: minimal
-#language: generic
+#language: minimal
+language: generic
 #python: 3.6.3
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
@@ -94,7 +94,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
 #    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; python3 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
       #- if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ before_install:
     - sudo apt-get update -y
     - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-    - export PYTHONPATH=/usr/lib/python3.6/
-    - export PYTHONHOME=/usr/lib/python3.6/
+ #   - export PYTHONPATH=/usr/lib/python3.6/
+ #   - export PYTHONHOME=/usr/lib/python3.6/
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
@@ -94,7 +94,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
       #- if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python 3.6.3 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-#    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_install:
     - sudo apt-get update -y
     - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
- #   - export PYTHONPATH=/usr/lib/python3.6/
+    - export PYTHONPATH=/usr/lib/python3.6/
  #   - export PYTHONHOME=/usr/lib/python3.6/
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: required
 dist: trusty
 os: linux
-#language: minimal
-language: generic
-python: 3.6.3
+language: minimal
+#language: generic
+#python: 3.6.3
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:
@@ -47,9 +47,9 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-#    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-#    - sudo apt-get update -y
-#    - sudo apt-get install -y python3.6
+    - sudo add-apt-repository -y ppa:deadsnakes/ppa
+    - sudo apt-get update -y
+    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     - export PYTHONPATH=/usr/lib/python3.6/
     - export PYTHONHOME=/usr/lib/python3.6/

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+      #- if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-    - sudo apt-get update -y
-    - sudo apt-get install -y python3.6
+#    - sudo add-apt-repository -y ppa:deadsnakes/ppa
+#    - sudo apt-get update -y
+#    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-    - export PYTHONPATH=/usr/lib/python3.6/
+#    - export PYTHONPATH=/usr/lib/python3.6/
  #   - export PYTHONHOME=/usr/lib/python3.6/
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
@@ -94,7 +94,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
 #    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; python3.6 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 dist: trusty
 os: linux
 language: minimal
+python:
+  - 3.6
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:
@@ -44,9 +46,9 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-    - sudo apt-get update -y
-    - sudo apt-get install -y python3.6
+        #    - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        #    - sudo apt-get update -y
+        #    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ before_install:
 #    - sudo apt-get update -y
 #    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-    - export PYTHONPATH=/usr/lib/python3.6
+    - export PYTHONPATH=/usr/lib/python3.6/
+    - export PYTHONHOME=/usr/lib/python3.6/
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
@@ -92,8 +93,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-      #- if [ "$RUN_TESTS" = "true" ]; then python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+      #- if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python 3.6.3 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
 # 32-bit + dash
 #    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
 # Win64
-###    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
     - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 # x86_64 Linux, No wallet

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 os: linux
 #language: minimal
-language: generic
+language: python
 python: 
   - 3.6
 notifications:
@@ -28,7 +28,6 @@ env:
     - WINEDEBUG=fixme-all
     - BOOST_TEST_LOG_LEVEL=test_suite
     - BOOST_TEST_BUILD_INFO=yes
-#    - PYTHON_BINARY="python3.6"
   matrix:
 # ARM
 #    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: required
 dist: trusty
 os: linux
 language: minimal
-python:
-  - 3.6
+#python:
+#  - 3.6
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:
@@ -27,6 +27,7 @@ env:
     - WINEDEBUG=fixme-all
     - BOOST_TEST_LOG_LEVEL=test_suite
     - BOOST_TEST_BUILD_INFO=yes
+    - PYTHON_BINARY="python3.6"
   matrix:
 # ARM
 #    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
@@ -46,9 +47,9 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-        #    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-        #    - sudo apt-get update -y
-        #    - sudo apt-get install -y python3.6
+    - sudo add-apt-repository -y ppa:deadsnakes/ppa
+    - sudo apt-get update -y
+    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
@@ -90,7 +91,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-    - if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=4000 --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
 #    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib/; python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
-    - if [ "$RUN_TESTS" = "true" ]; then python --version; python3 --version; python3.6 --version; eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
+    - if [ "$RUN_TESTS" = "true" ]; then ls -la /usr/lib; python --version; python3 --version; python3.6 --version; python3 eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: required
 dist: trusty
 os: linux
-language: minimal
-#python:
-#  - 3.6
+#language: minimal
+language: generic
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:
@@ -27,7 +26,7 @@ env:
     - WINEDEBUG=fixme-all
     - BOOST_TEST_LOG_LEVEL=test_suite
     - BOOST_TEST_BUILD_INFO=yes
-    - PYTHON_BINARY="python3.6"
+#    - PYTHON_BINARY="python3.6"
   matrix:
 # ARM
 #    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
@@ -47,9 +46,9 @@ env:
 #    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
-    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-    - sudo apt-get update -y
-    - sudo apt-get install -y python3.6
+#    - sudo add-apt-repository -y ppa:deadsnakes/ppa
+#    - sudo apt-get update -y
+#    - sudo apt-get install -y python3.6
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 os: linux
 #language: minimal
 language: generic
+python: 3.6.3
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:
@@ -90,7 +91,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
-      #- if [ "$RUN_TESTS" = "true" ]; then python3.6 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+      #- if [ "$RUN_TESTS" = "true" ]; then python3.6.3 eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
     - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py p2p_invalid_block.py --combinedlogslen=40 --coverage --quiet; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 os: linux
 #language: minimal
 language: generic
-#python: 3.6.3
+python: 3.6
 notifications:
   slack: equibit:vlkY7tTE9BPTwi1QnrMIMb6e
 cache:

--- a/eqbtest/functional/mining_basic.py
+++ b/eqbtest/functional/mining_basic.py
@@ -64,23 +64,23 @@ class MiningTest(BitcoinTestFramework):
         block.nNonce = 0
         block.vtx = [coinbase_tx]
 
-        # self.log.info("getblocktemplate: Test valid block")
-        # assert_template(node, block, None)
-        #
-        # self.log.info("submitblock: Test block decode failure")
-        # assert_raises_rpc_error(-22, "Block decode failed", node.submitblock, b2x(block.serialize()[:-15]))
-        #
-        # self.log.info("getblocktemplate: Test bad input hash for coinbase transaction")
-        # bad_block = copy.deepcopy(block)
-        # bad_block.vtx[0].vin[0].prevout.hash += 1
-        # bad_block.vtx[0].rehash()
-        # assert_template(node, bad_block, 'bad-cb-missing')
-        #
-        # self.log.info("submitblock: Test invalid coinbase transaction")
-        # assert_raises_rpc_error(-22, "Block does not start with a coinbase", node.submitblock, b2x(bad_block.serialize()))
-        #
-        # self.log.info("getblocktemplate: Test truncated final transaction")
-        # assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': b2x(block.serialize()[:-1]), 'mode': 'proposal'})
+        self.log.info("getblocktemplate: Test valid block")
+        assert_template(node, block, None)
+
+        self.log.info("submitblock: Test block decode failure")
+        assert_raises_rpc_error(-22, "Block decode failed", node.submitblock, b2x(block.serialize()[:-15]))
+
+        self.log.info("getblocktemplate: Test bad input hash for coinbase transaction")
+        bad_block = copy.deepcopy(block)
+        bad_block.vtx[0].vin[0].prevout.hash += 1
+        bad_block.vtx[0].rehash()
+        assert_template(node, bad_block, 'bad-cb-missing')
+
+        self.log.info("submitblock: Test invalid coinbase transaction")
+        assert_raises_rpc_error(-22, "Block does not start with a coinbase", node.submitblock, b2x(bad_block.serialize()))
+
+        self.log.info("getblocktemplate: Test truncated final transaction")
+        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': b2x(block.serialize()[:-1]), 'mode': 'proposal'})
 
         self.log.info("getblocktemplate: Test duplicate transaction")
         bad_block = copy.deepcopy(block)

--- a/eqbtest/functional/mining_basic.py
+++ b/eqbtest/functional/mining_basic.py
@@ -64,23 +64,23 @@ class MiningTest(BitcoinTestFramework):
         block.nNonce = 0
         block.vtx = [coinbase_tx]
 
-        self.log.info("getblocktemplate: Test valid block")
-        assert_template(node, block, None)
-
-        self.log.info("submitblock: Test block decode failure")
-        assert_raises_rpc_error(-22, "Block decode failed", node.submitblock, b2x(block.serialize()[:-15]))
-
-        self.log.info("getblocktemplate: Test bad input hash for coinbase transaction")
-        bad_block = copy.deepcopy(block)
-        bad_block.vtx[0].vin[0].prevout.hash += 1
-        bad_block.vtx[0].rehash()
-        assert_template(node, bad_block, 'bad-cb-missing')
-
-        self.log.info("submitblock: Test invalid coinbase transaction")
-        assert_raises_rpc_error(-22, "Block does not start with a coinbase", node.submitblock, b2x(bad_block.serialize()))
-
-        self.log.info("getblocktemplate: Test truncated final transaction")
-        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': b2x(block.serialize()[:-1]), 'mode': 'proposal'})
+        # self.log.info("getblocktemplate: Test valid block")
+        # assert_template(node, block, None)
+        #
+        # self.log.info("submitblock: Test block decode failure")
+        # assert_raises_rpc_error(-22, "Block decode failed", node.submitblock, b2x(block.serialize()[:-15]))
+        #
+        # self.log.info("getblocktemplate: Test bad input hash for coinbase transaction")
+        # bad_block = copy.deepcopy(block)
+        # bad_block.vtx[0].vin[0].prevout.hash += 1
+        # bad_block.vtx[0].rehash()
+        # assert_template(node, bad_block, 'bad-cb-missing')
+        #
+        # self.log.info("submitblock: Test invalid coinbase transaction")
+        # assert_raises_rpc_error(-22, "Block does not start with a coinbase", node.submitblock, b2x(bad_block.serialize()))
+        #
+        # self.log.info("getblocktemplate: Test truncated final transaction")
+        # assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': b2x(block.serialize()[:-1]), 'mode': 'proposal'})
 
         self.log.info("getblocktemplate: Test duplicate transaction")
         bad_block = copy.deepcopy(block)

--- a/eqbtest/functional/test_framework/messages.py
+++ b/eqbtest/functional/test_framework/messages.py
@@ -593,6 +593,7 @@ class CBlock(CBlockHeader):
             newhashes = []
             for i in range(0, len(hashes), 2):
                 i2 = min(i+1, len(hashes)-1)
+                # Switch to SHA3_256
                 # newhashes.append(hash256(hashes[i] + hashes[i2]))
                 newhashes.append(hash3_256(hashes[i] + hashes[i2]))
             hashes = newhashes
@@ -601,8 +602,9 @@ class CBlock(CBlockHeader):
     def calc_merkle_root(self):
         hashes = []
         for tx in self.vtx:
-            # tx.calc_sha256()
-            tx.calc_sha3_256()
+            tx.calc_sha256()
+            # TODO: DON'T Swithch Tx hash calculation to SHA3_256 yet
+            # tx.calc_sha3_256()
             hashes.append(ser_uint256(tx.sha256))
         return self.get_merkle_root(hashes)
 

--- a/eqbtest/functional/test_framework/messages.py
+++ b/eqbtest/functional/test_framework/messages.py
@@ -46,13 +46,19 @@ NODE_NETWORK_LIMITED = (1 << 10)
 
 # Serialization/deserialization tools
 def sha256(s):
-    return hashlib.new('sha256', s).digest()
+    return hashlib.new('sha256', s).digest() #sha3_256 sha256
+
+def sha3_256(s):
+    return hashlib.new('sha3_256', s).digest()
 
 def ripemd160(s):
     return hashlib.new('ripemd160', s).digest()
 
 def hash256(s):
     return sha256(sha256(s))
+
+def hash3_256(s):
+    return sha3_256(sha3_256(s))
 
 def ser_compact_size(l):
     r = b""
@@ -474,6 +480,14 @@ class CTransaction():
             self.sha256 = uint256_from_str(hash256(self.serialize_without_witness()))
         self.hash = encode(hash256(self.serialize_without_witness())[::-1], 'hex_codec').decode('ascii')
 
+    def calc_sha3_256(self, with_witndess=False):
+        if with_witndess:
+            return uint256_from_str(hash3_256(self.serialize_with_witness()))
+
+        if self.sha256 is None:
+            self.sha256 = uint256_from_str(hash3_256(self.serialize_without_witness()))
+        self.hash = encode(hash3_256(self.serialize_without_witness())[::-1], 'hex_codec').decode('ascii')
+
     def is_valid(self):
         self.calc_sha256()
         for tout in self.vout:
@@ -579,14 +593,16 @@ class CBlock(CBlockHeader):
             newhashes = []
             for i in range(0, len(hashes), 2):
                 i2 = min(i+1, len(hashes)-1)
-                newhashes.append(hash256(hashes[i] + hashes[i2]))
+                # newhashes.append(hash256(hashes[i] + hashes[i2]))
+                newhashes.append(hash3_256(hashes[i] + hashes[i2]))
             hashes = newhashes
         return uint256_from_str(hashes[0])
 
     def calc_merkle_root(self):
         hashes = []
         for tx in self.vtx:
-            tx.calc_sha256()
+            # tx.calc_sha256()
+            tx.calc_sha3_256()
             hashes.append(ser_uint256(tx.sha256))
         return self.get_merkle_root(hashes)
 

--- a/eqbtest/functional/test_framework/messages.py
+++ b/eqbtest/functional/test_framework/messages.py
@@ -480,8 +480,8 @@ class CTransaction():
             self.sha256 = uint256_from_str(hash256(self.serialize_without_witness()))
         self.hash = encode(hash256(self.serialize_without_witness())[::-1], 'hex_codec').decode('ascii')
 
-    def calc_sha3_256(self, with_witndess=False):
-        if with_witndess:
+    def calc_sha3_256(self, with_witness=False):
+        if with_witness:
             return uint256_from_str(hash3_256(self.serialize_with_witness()))
 
         if self.sha256 is None:
@@ -603,7 +603,7 @@ class CBlock(CBlockHeader):
         hashes = []
         for tx in self.vtx:
             tx.calc_sha256()
-            # TODO: DON'T Swithch Tx hash calculation to SHA3_256 yet
+            # EQB_TODO: DON'T Switch Tx hash calculation to SHA3_256 yet
             # tx.calc_sha3_256()
             hashes.append(ser_uint256(tx.sha256))
         return self.get_merkle_root(hashes)


### PR DESCRIPTION
A fix to make these functional tests pass after core Merkle Root SHA3 implementation:
```
feature_block.py 
feature_cltv.py  
feature_csv_activation.py  
feature_dersig.py                
feature_nulldummy.py
mining_basic.py
p2p_compactblocks.py
p2p_invalid_block.py
p2p_segwit.py
p2p_unrequested_blocks.py
wallet_bumpfee.py
```
1. Modified `.travis.yml` to be able to run functional tests with Python3.6 which has updated `hashlib.py` library. `Hashlib v3.6` supports SHA3 algorithms.
1. Only MerkleRoot calculations switched to SHA3_256 in `eqbtest/framework/messages.py`