### PR TITLE
#149 Add SHA3 to serialization of DB files banlist.dat and peers.dat

### DIFF
--- a/eqbtest/functional/p2p_disconnect_ban.py
+++ b/eqbtest/functional/p2p_disconnect_ban.py
@@ -5,7 +5,7 @@
 """Test node disconnect and ban behavior"""
 import time
 
-from test_framework.test_framework import BitcoinTestFramework, SkipTest  # EQB_TODO: Remove import SkipTest class after fixing all the tests
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
@@ -18,7 +18,6 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.num_nodes = 2
 
     def run_test(self):
-        raise SkipTest("DOES NOT WORK: setban: test persistence across node restart")  # EQB_TODO: Fix the tests: 'setban: test persistence across node restart'
         self.log.info("Test setban and listbanned RPCs")
 
         self.log.info("setban: successfully ban single IP address")
@@ -69,9 +68,9 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.start_node(1)
 
         listAfterShutdown = self.nodes[1].listbanned()
-        # assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])  # EQB_TODO: disabled test
-        # assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])  # EQB_TODO: disabled test
-        # assert_equal("/19" in listAfterShutdown[2]['address'], True)   # EQB_TODO: disabled test
+        assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])
+        assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])
+        assert_equal("/19" in listAfterShutdown[2]['address'], True)
 
         # Clear ban lists
         self.nodes[1].clearbanned()

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2018 Equibit Group AG
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -21,7 +22,11 @@ bool SerializeDB(Stream& stream, const Data& data)
 {
     // Write and commit header, data
     try {
+#ifdef BUILD_BTC
         CHashWriter hasher(SER_DISK, CLIENT_VERSION);
+#else // BUILD_EQB
+        CSHA3HashWriter hasher(SER_DISK, CLIENT_VERSION);
+#endif // END_BUILD
         stream << FLATDATA(Params().MessageStart()) << data;
         hasher << FLATDATA(Params().MessageStart()) << data;
         stream << hasher.GetHash();


### PR DESCRIPTION
PR has SHA3 for SerializeDB() which is being used in checksum verification for 'banlist.dat' and 'peers.dat'. This fixes functional test 'p2p_disconnect_ban.py'.