### PR TITLE
#187 Add privKey-to-address and make-privKey EQB/BTC scripts

### DIFF
--- a/eqb/scripts/make_privateKey_from_number_BTC.py
+++ b/eqb/scripts/make_privateKey_from_number_BTC.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+'''
+for Bitcoin TestNet/MainNet, compressed/uncompressed. 
+Input: 64-symbol string representing Hex integer, or it will generate a random number.
+
+Examples:
+
+λ python make_privateKey_from_number_BTC.py 0000000000000000000000000000000000000000000000000000000000000001
+Private Key Compressed   TestNet:     b'ef00000000000000000000000000000000000000000000000000000000000000010184e38d1f'
+Private Key Compressed   TestNet B58: b'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA'
+Private Key Compressed   MainNet:     b'800000000000000000000000000000000000000000000000000000000000000001014671fc3f'
+Private Key Compressed   MainNet B58: b'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn'
+Private Key Uncompressed TestNet:     b'ef000000000000000000000000000000000000000000000000000000000000000140df3cbd'
+Private Key Uncompressed TestNet B58: b'91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'
+Private Key Uncompressed MainNet:     b'800000000000000000000000000000000000000000000000000000000000000001a85aa87e'
+Private Key Uncompressed MainNet B58: b'5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf'
+
+λ python make_privateKey_from_number_BTC.py
+Private Key Compressed   TestNet:     b'ef3d66cd078c8533fddcbb6d5c210c0278b65ae9a7c0a3d7cf43e50567153e7e8d016d6aaaa6'
+Private Key Compressed   TestNet B58: b'cPe4LF6jQCjour7Jwra2subCvbD6i1nLyNPiNyMeUDWhzvXcURZX'
+Private Key Compressed   MainNet:     b'803d66cd078c8533fddcbb6d5c210c0278b65ae9a7c0a3d7cf43e50567153e7e8d01a426d1ce'
+Private Key Compressed   MainNet B58: b'KyH4sL6sy93YkQe3ZSkuWb69JMuh3ZgeuLFFGYu8y6rhkBUNdg7f'
+Private Key Uncompressed TestNet:     b'ef3d66cd078c8533fddcbb6d5c210c0278b65ae9a7c0a3d7cf43e50567153e7e8da63310bb'
+Private Key Uncompressed TestNet B58: b'923xap9YowmbC4spZpUsitnp7FYjysUVYMFfNk8PzNQx4EAhhz2'
+Private Key Uncompressed MainNet:     b'803d66cd078c8533fddcbb6d5c210c0278b65ae9a7c0a3d7cf43e50567153e7e8dd1f632d3'
+Private Key Uncompressed MainNet B58: b'5JHL15L1DihTE1NXwUaxrJErTbC2phwJCQPiJ7mtedfuHDgYgVx'
+'''
+
+import sys
+import hashlib
+import base58check
+import codecs
+import ecdsa
+import secrets
+
+def checkSum(x_bytearray):
+	return codecs.encode(hashlib.new('sha256', (hashlib.new('sha256', codecs.decode(x_bytearray, 'hex')).digest())).digest(), 'hex')[0:8]
+
+def encode58(int_byteString):
+	return base58check.b58encode(codecs.decode(int_byteString, 'hex'))
+
+def generateRandomKey():
+	bits = secrets.randbits(256)
+	return hex(bits)[2:]
+
+privateKey_value = sys.argv[1] if len(sys.argv) > 1 else generateRandomKey()
+for (keyType, cmpByte) in [("Compressed", b'01'), ("Uncompressed", b'')]:
+	privateKeyTn_hex = b'ef' + privateKey_value.encode('utf-8') + cmpByte + checkSum(b'ef' + privateKey_value.encode('utf-8') + cmpByte)
+	privateKeyMn_hex = b'80' + privateKey_value.encode('utf-8') + cmpByte + checkSum(b'80' + privateKey_value.encode('utf-8') + cmpByte)
+	print("Private Key {:12} TestNet:     {}".format(keyType, privateKeyTn_hex))
+	print("Private Key {:12} TestNet B58: {}".format(keyType, encode58(privateKeyTn_hex)))
+	print("Private Key {:12} MainNet:     {}".format(keyType, privateKeyMn_hex))
+	print("Private Key {:12} MainNet B58: {}".format(keyType, encode58(privateKeyMn_hex)))

--- a/eqb/scripts/make_privateKey_from_number_EQB.py
+++ b/eqb/scripts/make_privateKey_from_number_EQB.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+'''
+for Equibit TestNet/MainNet, compressed/uncompressed. 
+Input: 64-symbol string representing Hex integer, or it will generate a random number.
+
+Examples:
+
+λ python make_privateKey_from_number_EQB.py 0000000000000000000000000000000000000000000000000000000000000001
+Private Key Compressed   TestNet:     b'ef000000000000000000000000000000000000000000000000000000000000000101fcab5f16'
+Private Key Compressed   TestNet B58: b'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87Jceaw6xD'
+Private Key Compressed   MainNet:     b'8000000000000000000000000000000000000000000000000000000000000000010156d8a6ad'
+Private Key Compressed   MainNet B58: b'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVi767W'
+Private Key Uncompressed TestNet:     b'ef0000000000000000000000000000000000000000000000000000000000000001b3fbe242'
+Private Key Uncompressed TestNet B58: b'91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwpWyxMF'
+Private Key Uncompressed MainNet:     b'8000000000000000000000000000000000000000000000000000000000000000011dfb883d'
+Private Key Uncompressed MainNet B58: b'5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAj5Zf8G'
+
+λ python make_privateKey_from_number_EQB.py
+Private Key Compressed   TestNet:     b'ef229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b27010a67b29b'
+Private Key Compressed   TestNet B58: b'cNjvEQUr3E6CfeMH6DuMadeoBgVJUfUWtqHtVfpuRtDYJEpfGALr'
+Private Key Compressed   MainNet:     b'80229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b27016445ae95'
+Private Key Compressed   MainNet B58: b'KxNvmVUzcAPwWCt1hp6EDK9jZTBtpDNppo9RPFNPvmZY3VnKWLr8'
+Private Key Uncompressed TestNet:     b'ef229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b272f1aee39'
+Private Key Uncompressed TestNet B58: b'91r9SEvtSRiWNtxoEsW5fS52rYbxcio7KYLEUnxG3vHtVrAmEDW'
+Private Key Uncompressed MainNet:     b'80229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b2706d8623d'
+Private Key Uncompressed MainNet B58: b'5J5WrW7LrCeNQqTWcXcAnqX5CtFFTZFuybUHQAbkiBYqioY3LQU'
+
+'''
+
+import sys
+import hashlib
+import base58check
+import codecs
+import ecdsa
+import secrets
+
+def checkSum(x_bytearray):
+	return codecs.encode(hashlib.new('sha3_256', (hashlib.new('sha3_256', codecs.decode(x_bytearray, 'hex')).digest())).digest(), 'hex')[0:8]
+
+def encode58(int_byteString):
+	return base58check.b58encode(codecs.decode(int_byteString, 'hex'))
+
+def generateRandomKey():
+	bits = secrets.randbits(256)
+	return hex(bits)[2:]
+
+privateKey_value = sys.argv[1] if len(sys.argv) > 1 else generateRandomKey()
+for (keyType, cmpByte) in [("Compressed", b'01'), ("Uncompressed", b'')]:
+	privateKeyTn_hex = b'ef' + privateKey_value.encode('utf-8') + cmpByte + checkSum(b'ef' + privateKey_value.encode('utf-8') + cmpByte)
+	privateKeyMn_hex = b'80' + privateKey_value.encode('utf-8') + cmpByte + checkSum(b'80' + privateKey_value.encode('utf-8') + cmpByte)
+	print("Private Key {:12} TestNet:     {}".format(keyType, privateKeyTn_hex))
+	print("Private Key {:12} TestNet B58: {}".format(keyType, encode58(privateKeyTn_hex)))
+	print("Private Key {:12} MainNet:     {}".format(keyType, privateKeyMn_hex))
+	print("Private Key {:12} MainNet B58: {}".format(keyType, encode58(privateKeyMn_hex)))

--- a/eqb/scripts/privateKey_to_pubKey_address_BTC.py
+++ b/eqb/scripts/privateKey_to_pubKey_address_BTC.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+'''
+Converts PrivateKey -> PublicKey -> PubKeyHash -> Address (legacy)
+Input: Base58-encoded private key (string)
+
+Example BTC:
+
+λ python privateKey_to_scriptPubKey_BTC.py cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA
+Base58 decoded Private Key: b'ef00000000000000000000000000000000000000000000000000000000000000010184e38d1f'
+Network prefix:   b'ef'
+Private Key:      b'0000000000000000000000000000000000000000000000000000000000000001'
+Compression flag: b'01'
+Check sum:        b'84e38d1f'
+Public Key raw:   b'79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
+Public Key:       b'0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+Public Key Hash (ripemd160 <- sha2_256): b'751e76e8199196d454941c45d1b3a323f1433bd6'
+Addres mainnet:   b'00751e76e8199196d454941c45d1b3a323f1433bd6510d1634'    B58: b'1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH'
+Addres testnet:   b'6f751e76e8199196d454941c45d1b3a323f1433bd655c484e3'    B58: b'mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r'
+'''
+
+import sys
+import hashlib
+import base58check
+import codecs
+import ecdsa
+
+def public_compressed(pk):
+	x = pk[0:64]
+	y = int.from_bytes(codecs.decode(pk[64:128], 'hex'), byteorder='big', signed='false')
+	prefix = b'02' if y % 2 == 0 else b'03'
+	return prefix + x
+
+def checkSum(pk):
+	return codecs.encode(hashlib.new('sha256', (hashlib.new('sha256', codecs.decode(pk, 'hex')).digest())).digest(), 'hex')[0:8]
+
+def encode58(int_byteString):
+	return base58check.b58encode(codecs.decode(int_byteString, 'hex'))
+
+privateKey_base58_str = sys.argv[1]
+privateKey_hex_str = codecs.encode((base58check.b58decode(privateKey_base58_str)), 'hex')
+print("Base58 decoded Private Key: {}".format(privateKey_hex_str))
+privKey_networkPrefix = privateKey_hex_str[0:2]
+privKey_crc = privateKey_hex_str[-8:]
+privKey_clean = privateKey_hex_str[2:66]
+privKey_compressionFlag = privateKey_hex_str[66:68] if len(privateKey_hex_str) == 76 else None
+print("Network prefix:   {}".format(privKey_networkPrefix))
+print("Private Key:      {}".format(privKey_clean))
+print("Compression flag: {}".format(privKey_compressionFlag))
+print("Check sum:        {}".format(privKey_crc))
+
+pubKey_raw = codecs.encode(ecdsa.SigningKey.from_string(codecs.decode(privKey_clean, 'hex'), curve=ecdsa.SECP256k1).verifying_key.to_string(), 'hex')
+print("Public Key raw:   {}".format(pubKey_raw))
+pubKeyFull = b'04' + pubKey_raw if privKey_compressionFlag is None else public_compressed(pubKey_raw)
+print("Public Key:       {}".format(pubKeyFull))
+pubKey_s256 = codecs.encode(hashlib.new('sha256', codecs.decode(pubKeyFull, 'hex')).digest(), 'hex')
+publicKeyHash = codecs.encode(hashlib.new('ripemd160', codecs.decode(pubKey_s256, 'hex')).digest(), 'hex')
+print("Public Key Hash (ripemd160 <- sha2_256): {}".format(publicKeyHash))
+
+pubKeyHash_mainnet = b'00' + publicKeyHash
+pubKeyHash_testnet = b'6f' + publicKeyHash
+address_main = pubKeyHash_mainnet + checkSum(pubKeyHash_mainnet)
+address_test = pubKeyHash_testnet + checkSum(pubKeyHash_testnet)
+print("Addres mainnet:   {}    B58: {}".format(address_main, encode58(address_main)))
+print("Addres testnet:   {}    B58: {}".format(address_test, encode58(address_test)))

--- a/eqb/scripts/privateKey_to_pubKey_address_EQB.py
+++ b/eqb/scripts/privateKey_to_pubKey_address_EQB.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+'''
+Converts PrivateKey -> PublicKey -> PubKeyHash -> Address (legacy)
+Input: Base58-encoded private key (string)
+
+Example EQB:
+
+λ python privateKey_to_scriptPubKey_EQB.py cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA
+Base58 decoded Private Key: b'ef00000000000000000000000000000000000000000000000000000000000000010184e38d1f'
+Network prefix:   b'ef'
+Private Key:      b'0000000000000000000000000000000000000000000000000000000000000001'
+Compression flag: b'01'
+Check sum:        b'84e38d1f'
+Public Key raw:   b'79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
+Public Key:       b'0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+Public Key Hash (ripemd160 <- sha3_256): b'bd73d439ac57c49a438f609342df72f35934e912'
+Addres mainnet:   b'00bd73d439ac57c49a438f609342df72f35934e912b832b64f'    B58: b'1JGjUCPP65653XPHqZ6Qdkr5H81tZ9FYVk'
+Addres testnet:   b'6fbd73d439ac57c49a438f609342df72f35934e912a05ce03c'    B58: b'mxngmFUMu6XKpdruZ84nTg4Q97cbTXfUFu'
+'''
+
+import sys
+import hashlib
+import base58check
+import codecs
+import ecdsa
+
+def public_compressed(pk):
+	x = pk[0:64]
+	y = int.from_bytes(codecs.decode(pk[64:128], 'hex'), byteorder='big', signed='false')
+	prefix = b'02' if y % 2 == 0 else b'03'
+	return prefix + x
+
+def checkSum(pk):
+	return codecs.encode(hashlib.new('sha3_256', (hashlib.new('sha3_256', codecs.decode(pk, 'hex')).digest())).digest(), 'hex')[0:8]
+
+def encode58(int_byteString):
+	return base58check.b58encode(codecs.decode(int_byteString, 'hex'))
+
+privateKey_base58_str = sys.argv[1]
+privateKey_hex_str = codecs.encode((base58check.b58decode(privateKey_base58_str)), 'hex')
+print("Base58 decoded Private Key: {}".format(privateKey_hex_str))
+privKey_networkPrefix = privateKey_hex_str[0:2]
+privKey_crc = privateKey_hex_str[-8:]
+privKey_clean = privateKey_hex_str[2:66]
+privKey_compressionFlag = privateKey_hex_str[66:68] if len(privateKey_hex_str) == 76 else None
+print("Network prefix:   {}".format(privKey_networkPrefix))
+print("Private Key:      {}".format(privKey_clean))
+print("Compression flag: {}".format(privKey_compressionFlag))
+print("Check sum:        {}".format(privKey_crc))
+
+pubKey_raw = codecs.encode(ecdsa.SigningKey.from_string(codecs.decode(privKey_clean, 'hex'), curve=ecdsa.SECP256k1).verifying_key.to_string(), 'hex')
+print("Public Key raw:   {}".format(pubKey_raw))
+pubKeyFull = b'04' + pubKey_raw if privKey_compressionFlag is None else public_compressed(pubKey_raw)
+print("Public Key:       {}".format(pubKeyFull))
+pubKey_s3_256 = codecs.encode(hashlib.new('sha3_256', codecs.decode(pubKeyFull, 'hex')).digest(), 'hex')
+publicKeyHash = codecs.encode(hashlib.new('ripemd160', codecs.decode(pubKey_s3_256, 'hex')).digest(), 'hex')
+print("Public Key Hash (ripemd160 <- sha3_256): {}".format(publicKeyHash))
+
+pubKeyHash_mainnet = b'00' + publicKeyHash
+pubKeyHash_testnet = b'6f' + publicKeyHash
+address_main = pubKeyHash_mainnet + checkSum(pubKeyHash_mainnet)
+address_test = pubKeyHash_testnet + checkSum(pubKeyHash_testnet)
+print("Addres mainnet:   {}    B58: {}".format(address_main, encode58(address_main)))
+print("Addres testnet:   {}    B58: {}".format(address_test, encode58(address_test)))


### PR DESCRIPTION
I have added four Python scripts to `eqb/scripts` folder, one pair is to create/generate private key (TestNet/MainNet, BTC/EQB) and the other two are for private key -> public key/address(legacy) conversion.

Examples:

1. Convert hex number to the private keys
```
λ:\ python make_privateKey_from_number_EQB.py 0000000000000000000000000000000000000000000000000000000000000001
Private Key Compressed   TestNet:     b'ef000000000000000000000000000000000000000000000000000000000000000101fcab5f16'
Private Key Compressed   TestNet B58: b'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87Jceaw6xD'
Private Key Compressed   MainNet:     b'8000000000000000000000000000000000000000000000000000000000000000010156d8a6ad'
Private Key Compressed   MainNet B58: b'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVi767W'
Private Key Uncompressed TestNet:     b'ef0000000000000000000000000000000000000000000000000000000000000001b3fbe242'
Private Key Uncompressed TestNet B58: b'91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwpWyxMF'
Private Key Uncompressed MainNet:     b'8000000000000000000000000000000000000000000000000000000000000000011dfb883d'
Private Key Uncompressed MainNet B58: b'5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAj5Zf8G'
```
1a. Generate 256-bit number and do [1]:
```
λ:\ python make_privateKey_from_number_EQB.py
Private Key Compressed   TestNet:     b'ef229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b27010a67b29b'
Private Key Compressed   TestNet B58: b'cNjvEQUr3E6CfeMH6DuMadeoBgVJUfUWtqHtVfpuRtDYJEpfGALr'
Private Key Compressed   MainNet:     b'80229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b27016445ae95'
Private Key Compressed   MainNet B58: b'KxNvmVUzcAPwWCt1hp6EDK9jZTBtpDNppo9RPFNPvmZY3VnKWLr8'
Private Key Uncompressed TestNet:     b'ef229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b272f1aee39'
Private Key Uncompressed TestNet B58: b'91r9SEvtSRiWNtxoEsW5fS52rYbxcio7KYLEUnxG3vHtVrAmEDW'
Private Key Uncompressed MainNet:     b'80229435dcdf98abea2a3684c6c7b9a7fc045caf2e8a980e3eb75870acd9af2b2706d8623d'
Private Key Uncompressed MainNet B58: b'5J5WrW7LrCeNQqTWcXcAnqX5CtFFTZFuybUHQAbkiBYqioY3LQU'
```

2. Convert Base58-private key from [1, 1a] into a public key/public key hash/test & main addresses:
```
λ:\ python privateKey_to_scriptPubKey_EQB.py cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA
Base58 decoded Private Key: b'ef00000000000000000000000000000000000000000000000000000000000000010184e38d1f'
Network prefix:   b'ef'
Private Key:      b'0000000000000000000000000000000000000000000000000000000000000001'
Compression flag: b'01'
Check sum:        b'84e38d1f'
Public Key raw:   b'79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
Public Key:       b'0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
Public Key Hash (ripemd160 <- sha3_256): b'bd73d439ac57c49a438f609342df72f35934e912'
Addres mainnet:   b'00bd73d439ac57c49a438f609342df72f35934e912b832b64f'    B58: b'1JGjUCPP65653XPHqZ6Qdkr5H81tZ9FYVk'
Addres testnet:   b'6fbd73d439ac57c49a438f609342df72f35934e912a05ce03c'    B58: b'mxngmFUMu6XKpdruZ84nTg4Q97cbTXfUFu'
```


