### PR TITLE
#245 Add p2p_leak test

### DIFF
--- a/eqbtest/functional/p2p_leak.py
+++ b/eqbtest/functional/p2p_leak.py
@@ -12,10 +12,12 @@ into sending us something it shouldn't.
 
 Also test that nodes that send unsupported service bits to bitcoind are disconnected
 and don't receive a VERACK. Unsupported service bits are currently 1 << 5 and
-1 << 7 (until August 1st 2018)."""
+1 << 7 (until August 1st 2018).
+Update: This part is not relevant anymore since the Genesis Block was regenerated in November 2017
+"""
 
 from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 banscore = 10
@@ -28,7 +30,7 @@ class CLazyNode(P2PInterface):
 
     def bad_message(self, message):
         self.unexpected_msg = True
-        self.log.info("should not have received message: %s" % message.command)
+        self.log("should not have received message: %s" % message.command)
 
     def on_open(self):
         self.ever_connected = True
@@ -95,22 +97,17 @@ class P2PLeakTest(BitcoinTestFramework):
         self.extra_args = [['-banscore='+str(banscore)]]
 
     def run_test(self):
-        raise SkipTest("Disabled after Genesis Block timestamp change in issues /#121-reconf")  # EQB_TODO: disabled test
-        self.nodes[0].setmocktime(1544046012)  # 1501545600 August 1st 2017   NO25-2017 - genesis 1543251779: + 24h
+        self.nodes[0].setmocktime(1544046012)  # GMT: Wednesday, 5 December 2018 г., 21:40:12
 
         no_version_bannode = self.nodes[0].add_p2p_connection(CNodeNoVersionBan(), send_version=False)
         no_version_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVersionIdle(), send_version=False)
         no_verack_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVerackIdle())
-        unsupported_service_bit5_node = self.nodes[0].add_p2p_connection(CLazyNode(), services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_5)
-        unsupported_service_bit7_node = self.nodes[0].add_p2p_connection(CLazyNode(), services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_7)
 
         network_thread_start()
 
         wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=mininode_lock)
         wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=mininode_lock)
         wait_until(lambda: no_verack_idlenode.version_received, timeout=10, lock=mininode_lock)
-        wait_until(lambda: unsupported_service_bit5_node.ever_connected, timeout=10, lock=mininode_lock)
-        wait_until(lambda: unsupported_service_bit7_node.ever_connected, timeout=10, lock=mininode_lock)
 
         # Mine a block and make sure that it's not sent to the connected nodes
         self.nodes[0].generate(1)
@@ -120,10 +117,6 @@ class P2PLeakTest(BitcoinTestFramework):
 
         #This node should have been banned
         assert no_version_bannode.state != "connected"
-
-        # These nodes should have been disconnected
-        assert unsupported_service_bit5_node.state != "connected"
-        assert unsupported_service_bit7_node.state != "connected"
 
         self.nodes[0].disconnect_p2ps()
 
@@ -135,11 +128,8 @@ class P2PLeakTest(BitcoinTestFramework):
         assert(no_version_bannode.unexpected_msg == False)
         assert(no_version_idlenode.unexpected_msg == False)
         assert(no_verack_idlenode.unexpected_msg == False)
-        assert not unsupported_service_bit5_node.unexpected_msg
-        assert not unsupported_service_bit7_node.unexpected_msg
 
         self.log.info("Service bits 5 and 7 are allowed after August 1st 2018")
-        self.nodes[0].setmocktime(1501632000)  # 1533168000 August 2nd 2018   1543338179
 
         allowed_service_bit5_node = self.nodes[0].add_p2p_connection(P2PInterface(), services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_5)
         allowed_service_bit7_node = self.nodes[0].add_p2p_connection(P2PInterface(), services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_7)


### PR DESCRIPTION
Re-enabled `p2p_leak` test with some removed checks (related to August 1st 2018), which are not valid anymore due to regenerated genesis block.