### PR TITLE
#348 Add script to upload Windows binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - WINEDEBUG=fixme-all
     - BOOST_TEST_LOG_LEVEL=test_suite
     - BOOST_TEST_BUILD_INFO=yes
+    - OS_WIN=true
   matrix:
 # ARM
 #    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
@@ -39,7 +40,7 @@ env:
 # Win64
     - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
+    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true OS_WIN=false GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 # x86_64 Linux, No wallet
 #    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3" DEP_OPTS="NO_WALLET=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Cross-Mac
@@ -88,6 +89,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then cat src/test/test_bitcoin.log; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude feature_pruning,feature_dbcrash"; fi
     - if [ "$RUN_TESTS" = "true" ]; then eqbtest/functional/test_runner.py --combinedlogslen=40 --coverage --quiet ${extended}; fi
+    # upload Windows binary files to https://github.com/Equibit/CoreBinaries
+    - if [ "$OS_WIN" = "true" ]; then /home/travis/build/Equibit/equibit-core/publish.sh; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Upload Windows exe files to https://github.com/Equibit/CoreBinaries/dev/
+
+EQUIBIT_VERSION=0.2.1
+BUILD_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+echo "--------------------- Publishing Core Binaries ---------------------"
+git clone https://$GH_USR:$GH_TKN@github.com/Equibit/CoreBinaries.git
+cd CoreBinaries/dev && mkdir -p ${EQUIBIT_VERSION}/${BUILD_TIMESTAMP}/
+cp /home/travis/build/Equibit/equibit-core/build/equibit-x86_64-w64-mingw32/src/*.exe ${EQUIBIT_VERSION}/${BUILD_TIMESTAMP}
+git add *
+git commit -m "Copy Equibit binaries to ${EQUIBIT_VERSION}/${BUILD_TIMESTAMP}"
+git push origin master
+


### PR DESCRIPTION
Has modified `.travis.yml` and `publish.sh` script for uploading Windows binaries to https://github.com/Equibit/CoreBinaries/tree/master/dev/